### PR TITLE
Converted Int's internal storage from a raw pointer to Unique. This a…

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,7 @@
 #![allow(dead_code)] // Work in progress
 
 #![feature(core, asm, alloc, associated_consts)]
-#![feature(zero_one, step_trait)]
+#![feature(zero_one, step_trait, unique)]
 
 #![cfg_attr(test, feature(test))]
 


### PR DESCRIPTION
…utomatically provides the correct Send/Sync impls, provides an extra barrier to accidentally mutating supposedly immutable data, and allows Option<Int> to take less space.