### PR TITLE
Int % primitive should use %, not /, internally.

### DIFF
--- a/src/int.rs
+++ b/src/int.rs
@@ -2080,7 +2080,7 @@ macro_rules! impl_arith_prim (
                     return self;
                 }
 
-                return self / Limb(other as BaseInt);
+                return self % Limb(other.abs() as BaseInt);
             }
         }
 
@@ -2196,7 +2196,7 @@ macro_rules! impl_arith_prim (
                     return self;
                 }
 
-                return self / Limb(other as BaseInt);
+                return self % Limb(other as BaseInt);
             }
         }
         impl_arith_prim!(common $t);


### PR DESCRIPTION
Also, negative numbers were being handled incorrectly: x % y == x % |y|.