### PR TITLE
Tweak quickcheck tests.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,18 +6,14 @@ install: |
     curl -sL https://static.rust-lang.org/dist/rust-nightly-$TARGET.tar.gz | tar --strip-components=1 -C ~/rust -xzf -
 
 before_script: |
+    sudo apt-get update && \
     if [ $BITS -eq 32 ]; then \
-      sudo apt-get update && \
-      sudo apt-get install libc6-dev:i386 libstdc++6:i386 zlib1g-dev:i386 libssl-dev:i386 pkg-config:i386 gcc-multilib; \
+      sudo apt-get install libc6-dev:i386 libstdc++6:i386 zlib1g-dev:i386 libssl-dev:i386 pkg-config:i386 gcc-multilib libgmp-dev:i386; \
+    else \
+      sudo apt-get install libgmp-dev
     fi && \
     sudo ~/rust/install.sh
     pip install 'travis-cargo<0.2' --user && export PATH=$HOME/.local/bin:$PATH
-
-addons:
-  apt:
-    packages:
-      - libgmp-dev
-      - libgmp10:i386
 
 script:
   - |

--- a/tests/quickcheck.rs
+++ b/tests/quickcheck.rs
@@ -371,8 +371,7 @@ test_binop! {
     sub: -, -=, true, all;
     mul: *, *=, true, all;
     div: /, /=, false, all;
-    // FIXME(#24): rem gives incorrect results
-    // rem: %, %=, false, all;
+    rem: %, %=, false, all;
     bitand: &, &=, true, any;
     bitor: |, |=, true, any;
     bitxor: ^, ^=, true, any;


### PR DESCRIPTION
The `%` tests pass now that #32 and #33 have landed.

Bias the quickcheck distribution toward sequences of 0's and sequences of f's (see commit message for more info).