### PR TITLE
Implement `bit_length` and `bit` for fast bit analysis.

### DIFF
--- a/tests/quickcheck.rs
+++ b/tests/quickcheck.rs
@@ -186,6 +186,20 @@ fn count_ones(a: BigIntStr) {
                ag.popcount());
 }
 
+#[quickcheck]
+fn bit_length(a: BigIntStr) {
+    let (ar, ag) = a.parse();
+
+    assert_eq!(ar.bit_length(), ag.bit_length() as u32)
+}
+
+#[quickcheck]
+fn bit(a: BigIntStr, bit: u16) {
+    let (ar, ag) = a.parse();
+
+    assert_eq!(ar.bit(bit as u32), ag.tstbit(bit as usize));
+}
+
 // operators
 
 macro_rules! expr {


### PR DESCRIPTION
These are much faster than trying to implement them naively (e.g. `x.bit(y)`
could be `x & (Int::from(1) << y) != 0`).