### PR TITLE
Implement bit-ops between Int and primitives.

### DIFF
--- a/tests/quickcheck.rs
+++ b/tests/quickcheck.rs
@@ -233,7 +233,7 @@ macro_rules! expr {
     ($e: expr) => { $e }
 }
 macro_rules! test_binop {
-    ($($name: ident: $op: tt, $assign: tt, $allow_zero: expr, $primitives: ident;)*) => {
+    ($($name: ident: $op: tt, $assign: tt, $allow_zero: expr;)*) => {
         $(mod $name {
             #![allow(unused_imports)]
             use ::BigIntStr;
@@ -270,7 +270,6 @@ macro_rules! test_binop {
                 eq!(&ar $op &br, ag $op bg)
             }
 
-            #[cfg($primitives())]
             #[quickcheck]
             fn int_limb(a: BigIntStr, b: BaseInt) -> TestResult {
                 if !$allow_zero && b == 0 {
@@ -281,7 +280,6 @@ macro_rules! test_binop {
 
                 eq!(ar $op Limb(b), ag $op bg)
             }
-            #[cfg($primitives())]
             #[quickcheck]
             fn int_baseint(a: BigIntStr, b: BaseInt) -> TestResult {
                 if !$allow_zero && b == 0 {
@@ -292,7 +290,6 @@ macro_rules! test_binop {
 
                 eq!(ar $op b, ag $op bg)
             }
-            #[cfg($primitives())]
             #[quickcheck]
             fn int_i32(a: BigIntStr, b: i32) -> TestResult {
                 if !$allow_zero && b == 0 {
@@ -303,7 +300,6 @@ macro_rules! test_binop {
 
                 eq!(ar $op b, ag $op bg)
             }
-            #[cfg($primitives())]
             #[quickcheck]
             fn int_usize(a: BigIntStr, b: usize) -> TestResult {
                 if !$allow_zero && b == 0 {
@@ -315,7 +311,6 @@ macro_rules! test_binop {
                 eq!(ar $op b, ag $op bg)
             }
 
-            #[cfg($primitives())]
             #[quickcheck]
             fn baseint_int(a: BaseInt, b: BigIntStr) -> TestResult {
                 let ag = Mpz::from(a);
@@ -323,7 +318,6 @@ macro_rules! test_binop {
 
                 eq!(a $op br, ag $op bg)
             }
-            #[cfg($primitives())]
             #[quickcheck]
             fn i32_int(a: i32, b: BigIntStr) -> TestResult {
                 let ag = Mpz::from(a);
@@ -331,7 +325,6 @@ macro_rules! test_binop {
 
                 eq!(a $op br, ag $op bg)
             }
-            #[cfg($primitives())]
             #[quickcheck]
             fn usize_int(a: usize, b: BigIntStr) -> TestResult {
                 let ag = Mpz::from(a as u64);
@@ -355,7 +348,6 @@ macro_rules! test_binop {
                 eq!(ar, ag $op bg)
             }
 
-            #[cfg($primitives())]
             #[quickcheck]
             fn assign_limb(a: BigIntStr, b: BaseInt) -> TestResult {
                 if !$allow_zero && b == 0 {
@@ -367,7 +359,6 @@ macro_rules! test_binop {
                 expr!(ar $assign Limb(b));
                 eq!(ar, ag $op bg)
             }
-            #[cfg($primitives())]
             #[quickcheck]
             fn assign_baseint(a: BigIntStr, b: BaseInt) -> TestResult {
                 if !$allow_zero && b == 0 {
@@ -379,7 +370,6 @@ macro_rules! test_binop {
                 expr!(ar $assign b);
                 eq!(ar, ag $op bg)
             }
-            #[cfg($primitives())]
             #[quickcheck]
             fn assign_i32(a: BigIntStr, b: i32) -> TestResult {
                 if !$allow_zero && b == 0 {
@@ -391,7 +381,6 @@ macro_rules! test_binop {
                 expr!(ar $assign b);
                 eq!(ar, ag $op bg)
             }
-            #[cfg($primitives())]
             #[quickcheck]
             fn assign_usize(a: BigIntStr, b: usize) -> TestResult {
                 if !$allow_zero && b == 0 {
@@ -408,14 +397,14 @@ macro_rules! test_binop {
 }
 
 test_binop! {
-    add: +, +=, true, all;
-    sub: -, -=, true, all;
-    mul: *, *=, true, all;
-    div: /, /=, false, all;
-    rem: %, %=, false, all;
-    bitand: &, &=, true, all;
-    bitor: |, |=, true, all;
-    bitxor: ^, ^=, true, all;
+    add: +, +=, true;
+    sub: -, -=, true;
+    mul: *, *=, true;
+    div: /, /=, false;
+    rem: %, %=, false;
+    bitand: &, &=, true;
+    bitor: |, |=, true;
+    bitxor: ^, ^=, true;
 }
 
 mod neg {

--- a/tests/quickcheck.rs
+++ b/tests/quickcheck.rs
@@ -277,7 +277,7 @@ macro_rules! test_binop {
                     return TestResult::discard()
                 }
                 let (ar, ag) = a.parse();
-                let bg = b as u64;
+                let bg = Mpz::from(b as u64);
 
                 eq!(ar $op Limb(b), ag $op bg)
             }
@@ -288,7 +288,7 @@ macro_rules! test_binop {
                     return TestResult::discard()
                 }
                 let (ar, ag) = a.parse();
-                let bg = b as u64;
+                let bg = Mpz::from(b as u64);
 
                 eq!(ar $op b, ag $op bg)
             }
@@ -310,7 +310,7 @@ macro_rules! test_binop {
                     return TestResult::discard()
                 }
                 let (ar, ag) = a.parse();
-                let bg = b as u64;
+                let bg = Mpz::from(b as u64);
 
                 eq!(ar $op b, ag $op bg)
             }
@@ -362,7 +362,7 @@ macro_rules! test_binop {
                     return TestResult::discard()
                 }
                 let (mut ar, ag) = a.parse();
-                let bg = b as u64;
+                let bg = Mpz::from(b as u64);
 
                 expr!(ar $assign Limb(b));
                 eq!(ar, ag $op bg)
@@ -374,7 +374,7 @@ macro_rules! test_binop {
                     return TestResult::discard()
                 }
                 let (mut ar, ag) = a.parse();
-                let bg = b as u64;
+                let bg = Mpz::from(b as u64);
 
                 expr!(ar $assign b);
                 eq!(ar, ag $op bg)
@@ -398,7 +398,7 @@ macro_rules! test_binop {
                     return TestResult::discard()
                 }
                 let (mut ar, ag) = a.parse();
-                let bg = b as u64;
+                let bg = Mpz::from(b as u64);
 
                 expr!(ar $assign b);
                 eq!(ar, ag $op bg)
@@ -413,9 +413,9 @@ test_binop! {
     mul: *, *=, true, all;
     div: /, /=, false, all;
     rem: %, %=, false, all;
-    bitand: &, &=, true, any;
-    bitor: |, |=, true, any;
-    bitxor: ^, ^=, true, any;
+    bitand: &, &=, true, all;
+    bitor: |, |=, true, all;
+    bitxor: ^, ^=, true, all;
 }
 
 mod neg {


### PR DESCRIPTION
This allows `some_int | 1`, etc.