### PR TITLE
Implement sqrt_rem, for square root & remainder computation.

### DIFF
--- a/tests/quickcheck.rs
+++ b/tests/quickcheck.rs
@@ -193,6 +193,21 @@ fn dsquare(a: BigIntStr) -> TestResult {
 }
 
 #[quickcheck]
+fn sqrt_rem(a: BigIntStr) -> TestResult {
+    let (ar, ag) = a.parse();
+    if ar < 0 {
+        return TestResult::discard();
+    }
+
+    let (s_r, rem_r) = ar.sqrt_rem().unwrap();
+    let s_g = ag.sqrt();
+    let rem_g = ag - &s_g * &s_g;
+
+    eq!(s_r, s_g);
+    eq!(rem_r, rem_g)
+}
+
+#[quickcheck]
 fn negate(a: BigIntStr) -> TestResult {
     let (mut ar, ag) = a.parse();
     ar.negate();


### PR DESCRIPTION
This uses Algorithm 1.12 of [1] \(specifically of Version 0.5.9 acquired
from \[2]).

[1]: Brent, Richard P.; Zimmermann, Paul (2010). *Modern Computer
     Arithmetic*. Cambridge University Press. ISBN 9780521194693.

\[2]: http://www.loria.fr/~zimmerma/mca/pub226.html