### PR TITLE
Add debug bounds checks via new LimbPtr{,Mut} types & fix problems this highlights

### DIFF
--- a/src/int.rs
+++ b/src/int.rs
@@ -858,7 +858,7 @@ impl PartialEq<Limb> for Int {
             return true;
         }
 
-        self.size == 1 && unsafe { *self.limbs() == *other }
+        self.size == 1 && *self.limbs() == *other
     }
 }
 
@@ -914,9 +914,7 @@ impl PartialOrd<Limb> for Int {
         } else if self.size > 1 {
             Some(Ordering::Greater)
         } else {
-            unsafe {
-                (*self.limbs()).partial_cmp(other)
-            }
+            (*self.limbs()).partial_cmp(other)
         }
     }
 }
@@ -1433,20 +1431,16 @@ impl<'a, 'b> Mul<&'a Int> for &'b Int {
         let out_sign = self.sign() * other.sign();
 
         if self.abs_size() == 1 {
-            unsafe {
-                let mut ret = other.clone() * *self.limbs();
-                let size = ret.abs_size();
-                ret.size = size * out_sign;
-                return ret;
-            }
+            let mut ret = other.clone() * *self.limbs();
+            let size = ret.abs_size();
+            ret.size = size * out_sign;
+            return ret;
         }
         if other.abs_size() == 1 {
-            unsafe {
-                let mut ret = self.clone() * *other.limbs();
-                let size = ret.abs_size();
-                ret.size = size * out_sign;
-                return ret;
-            }
+            let mut ret = self.clone() * *other.limbs();
+            let size = ret.abs_size();
+            ret.size = size * out_sign;
+            return ret;
         }
 
         let out_size = self.abs_size() + other.abs_size();
@@ -1482,11 +1476,9 @@ impl<'a> Mul<&'a Int> for Int {
 
         // `other` is a single limb, reuse the allocation of self
         if other.abs_size() == 1 {
-            unsafe {
-                let mut out = self * *other.limbs();
-                out.size *= other.sign();
-                return out;
-            }
+            let mut out = self * *other.limbs();
+            out.size *= other.sign();
+            return out;
         }
 
         // Forward to the by-reference impl
@@ -1516,13 +1508,13 @@ impl Mul<Int> for Int {
         // One of them is a single limb big, so we can re-use the
         // allocation of the other
         if self.abs_size() == 1 {
-            let val = unsafe { *self.limbs() };
+            let val = *self.limbs();
             let mut out = other * val;
             out.size *= self.sign();
             return out;
         }
         if other.abs_size() == 1 {
-            let val = unsafe { *other.limbs() };
+            let val = *other.limbs();
             let mut out = self * val;
             out.size *= other.sign();
             return out;
@@ -1603,7 +1595,7 @@ impl<'a, 'b> Div<&'a Int> for &'b Int {
             ll::divide_by_zero();
         }
         if other.abs_size() == 1 {
-            let l = unsafe { *other.limbs() };
+            let l = *other.limbs();
             let out_sign = self.sign() * other.sign();
             let mut out = self.clone() / l;
             out.size = out.abs_size() * out_sign;
@@ -1712,7 +1704,7 @@ impl<'a, 'b> Rem<&'a Int> for &'b Int {
             ll::divide_by_zero();
         }
         if other.abs_size() == 1 {
-            let l = unsafe { *other.limbs() };
+            let l = *other.limbs();
             return self.clone() % l;
         }
 
@@ -2960,9 +2952,7 @@ impl PartialEq<i32> for Int {
         // since it'll fail because of signs
         if sign < 0 {
             if self.abs_size() > 1 { return false; }
-            unsafe {
-                return *self.limbs() == (other.abs() as BaseInt);
-            }
+            return *self.limbs() == (other.abs() as BaseInt);
         }
 
         self.eq(&Limb(other.abs() as BaseInt))
@@ -3096,7 +3086,7 @@ fn cmp_64(x: &Int, mag: u64, neg: bool) -> Ordering {
         return size.cmp(&if neg {-1} else {1})
     }
     let ptr = x.limbs();
-    let lo_limb = unsafe {*ptr};
+    let lo_limb = *ptr;
 
     let mag_ord = if mag < MAX_LIMB {
         (size.abs(), lo_limb.0).cmp(&(1, mag as BaseInt))

--- a/src/int.rs
+++ b/src/int.rs
@@ -1855,14 +1855,15 @@ impl ShrAssign<usize> for Int {
             unsafe {
                 let ptr = self.limbs_mut();
                 let shift = ptr.offset(removed_limbs as isize);
+                let new_size = size - removed_limbs as i32;
 
                 // Shift down a whole number of limbs
-                ll::copy_incr(shift.as_const(), ptr, size);
+                ll::copy_incr(shift.as_const(), ptr, new_size);
                 // Zero out the high limbs
-                ll::zero(ptr.offset((size - (removed_limbs as i32)) as isize),
+                ll::zero(ptr.offset(new_size as isize),
                          removed_limbs as i32);
 
-                self.size -= (removed_limbs as i32) * self.sign();
+                self.size = new_size * self.sign();
             }
         }
 

--- a/src/int.rs
+++ b/src/int.rs
@@ -369,6 +369,9 @@ impl Int {
         if other.sign() == 0 {
             ll::divide_by_zero();
         }
+        if self.sign() == 0 {
+            return (self.clone(), Int::zero())
+        }
 
         let out_size = if self.abs_size() < other.abs_size() {
             1

--- a/src/ll/div.rs
+++ b/src/ll/div.rs
@@ -13,7 +13,7 @@
 //    limitations under the License.
 
 use std::intrinsics::assume;
-use std::cmp::Ordering;
+use std::cmp::{self, Ordering};
 
 use mem;
 use ll;
@@ -245,7 +245,11 @@ fn divrem_3by2(n2: Limb, n1: Limb, n0: Limb, d1: Limb, d0: Limb, dinv: Limb) -> 
 pub unsafe fn divrem(mut qp: LimbsMut, mut rp: LimbsMut,
                      np: Limbs, ns: i32,
                      dp: Limbs, ds: i32) {
-    debug_assert!(!overlap(qp, (ns - ds) + 1, np, ns));
+    // Space for at least one limb is always needed, even if
+    // (logarithmically) the result will be so small that negative
+    // would work.
+    let max_result_size = cmp::max((ns - ds) + 1, 1);
+    debug_assert!(!overlap(qp, max_result_size, np, ns));
 
     if ns < ds {
         *qp = Limb(0);

--- a/src/ll/div.rs
+++ b/src/ll/div.rs
@@ -41,6 +41,9 @@ pub unsafe fn divrem_1(mut qp: LimbsMut, qxn: i32,
     let mut n = xs + qxn;
     if n == 0 { return Limb(0); }
 
+    // FIXME (#49): this is used for bounds checks below, which may be
+    // unnecessary.
+    let qp_lo = qp;
     qp = qp.offset((n - 1) as isize);
 
     let mut r = Limb(0);
@@ -49,7 +52,9 @@ pub unsafe fn divrem_1(mut qp: LimbsMut, qxn: i32,
             r = *xp.offset((xs - 1) as isize);
             let q = if r >= d { Limb(1) } else { Limb(0) };
             *qp = q;
-            qp = qp.offset(-1);
+            if qp > qp_lo {
+                qp = qp.offset(-1);
+            }
             r = r - (d & -q);
             xs -= 1;
         }
@@ -61,7 +66,9 @@ pub unsafe fn divrem_1(mut qp: LimbsMut, qxn: i32,
             let (q, rem) = limb::div_preinv(r, n0, d, dinv);
             r = rem;
             *qp = q;
-            qp = qp.offset(-1);
+            if qp > qp_lo {
+                qp = qp.offset(-1);
+            }
             i -= 1;
         }
         let mut i = qxn - 1;
@@ -69,7 +76,9 @@ pub unsafe fn divrem_1(mut qp: LimbsMut, qxn: i32,
             let (q, rem) = limb::div_preinv(r, Limb(0), d, dinv);
             r = rem;
             *qp = q;
-            qp = qp.offset(-1);
+            if qp > qp_lo {
+                qp = qp.offset(-1);
+            }
             i -= 1;
         }
 
@@ -80,7 +89,9 @@ pub unsafe fn divrem_1(mut qp: LimbsMut, qxn: i32,
             if n1 < d {
                 r = n1;
                 *qp = Limb(0);
-                qp = qp.offset(-1);
+                if qp > qp_lo {
+                    qp = qp.offset(-1);
+                }
                 n -= 1;
                 if n == 0 {
                     return r;
@@ -114,7 +125,9 @@ pub unsafe fn divrem_1(mut qp: LimbsMut, qxn: i32,
             let (q, rem) = limb::div_preinv(r, n1 << cnt, d, dinv);
             r = rem;
             *qp = q;
-            qp = qp.offset(-1);
+            if qp > qp_lo {
+                qp = qp.offset(-1);
+            }
         }
 
         let mut i = qxn - 1;
@@ -123,7 +136,9 @@ pub unsafe fn divrem_1(mut qp: LimbsMut, qxn: i32,
             r = rem;
             *qp = q;
 
-            qp = qp.offset(-1);
+            if qp > qp_lo {
+                qp = qp.offset(-1);
+            }
             i -= 1;
         }
 

--- a/src/ll/limb_ptr.rs
+++ b/src/ll/limb_ptr.rs
@@ -1,0 +1,162 @@
+// Copyright 2015 The Ramp Developers
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+use ll::limb::Limb;
+
+use std::{fmt, ops};
+#[cfg(debug_assertions)]
+use std::mem;
+use std::cmp::Ordering;
+
+
+/// A version of `*const Limb` that is bounds-checked when debug assertions are on
+#[derive(Copy, Clone, Debug)]
+#[allow(raw_pointer_derive)]
+pub struct Limbs {
+    ptr: *const Limb,
+    bounds: Bounds,
+}
+
+/// A version of `*mut Limb` that is bounds-checked when debug assertions are on
+#[derive(Copy, Clone)]
+#[allow(raw_pointer_derive)]
+pub struct LimbsMut {
+    ptr: *mut Limb,
+    bounds: Bounds,
+}
+
+macro_rules! api {
+    ($ty: ident, $ptr: ty) => {
+        impl $ty {
+            /// Create a new instance, pointing at `base` and valid
+            /// from `base.offset(start)` to `base.offset(end)`.
+            pub unsafe fn new(base: $ptr, start: i32, end: i32) -> $ty {
+                $ty {
+                    ptr: base,
+                    bounds: Bounds::new(base as usize, start, end)
+                }
+            }
+
+            /// Move `self` to point to the `x`th Limbs from the
+            /// current location.
+            #[inline]
+            pub unsafe fn offset(self, x: isize) -> $ty {
+                debug_assert!(self.bounds.offset_valid(self.ptr as usize, x),
+                              "invalid offset of {:?} by {}, which should be in {:?}", self.ptr, x, self.bounds);
+                $ty {
+                    ptr: self.ptr.offset(x),
+                    bounds: self.bounds,
+                }
+            }
+        }
+
+        impl PartialEq for $ty {
+            fn eq(&self, other: &$ty) -> bool {
+                self.ptr == other.ptr
+            }
+        }
+        impl PartialOrd for $ty {
+            fn partial_cmp(&self, other: &$ty) -> Option<Ordering> {
+                self.ptr.partial_cmp(&other.ptr)
+            }
+        }
+        impl Eq for $ty {}
+        impl Ord for $ty {
+            fn cmp(&self, other: &$ty) -> Ordering {
+                self.ptr.cmp(&other.ptr)
+            }
+        }
+
+        impl ops::Deref for $ty {
+            type Target = Limb;
+            fn deref(&self) -> &Limb {
+                debug_assert!(self.bounds.can_deref(self.ptr as usize),
+                              "invalid deref of {:?}, which should be in {:?}", self.ptr, self.bounds);
+                unsafe { &*self.ptr }
+            }
+        }
+    }
+}
+
+api!(Limbs, *const Limb);
+api!(LimbsMut, *mut Limb);
+impl LimbsMut {
+    /// View the `LimbsMut` as a `Limbs` (an explicit `*const
+    /// Limb` -> `*mut Limb` conversion)
+    pub fn as_const(self) -> Limbs {
+        Limbs {
+            ptr: self.ptr,
+            bounds: self.bounds,
+        }
+    }
+}
+impl ops::DerefMut for LimbsMut {
+    fn deref_mut(&mut self) -> &mut Limb {
+        debug_assert!(self.bounds.can_deref(self.ptr as usize),
+                      "invalid mut deref of {:?}, which should be in {:?}", self.ptr, self.bounds);
+        unsafe { &mut *self.ptr }
+    }
+}
+
+// This is where the magic is at: the bounds are only stored/checked
+// in debug mode; release mode just powers ahead without any overhead.
+
+#[derive(Copy, Clone)]
+#[cfg(debug_assertions)]
+struct Bounds {
+    lo: usize,
+    hi: usize,
+}
+#[derive(Copy, Clone)]
+#[cfg(not(debug_assertions))]
+struct Bounds;
+
+#[cfg(debug_assertions)]
+impl Bounds {
+    fn new(ptr: usize, start: i32, end: i32) -> Bounds {
+        assert!(start <= end);
+        Bounds {
+            lo: ptr + start as usize * mem::size_of::<Limb>(),
+            hi: ptr + end as usize * mem::size_of::<Limb>(),
+        }
+    }
+    fn can_deref(self, ptr: usize) -> bool {
+        // a deref can't deref when we're at the limit
+        self.lo <= ptr && ptr < self.hi
+    }
+    fn offset_valid(self, ptr: usize, offset: isize) -> bool {
+        let bytes = offset * mem::size_of::<Limb>() as isize;
+        let new = ptr.wrapping_add(bytes as usize);
+        // an offset can point to the limit (i.e. one byte past the end)
+        self.lo <= new && new <= self.hi
+    }
+}
+#[cfg(not(debug_assertions))]
+impl Bounds {
+    fn new(_ptr: usize, _start: i32, _end: i32) -> Bounds { Bounds }
+    #[inline]
+    fn can_deref(self, _ptr: usize) -> bool { true }
+    #[inline]
+    fn offset_valid(self, _ptr: usize, _offset: isize) -> bool { true }
+}
+impl fmt::Debug for Bounds {
+    #[cfg(debug_assertions)]
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "Bounds {{ lo: 0x{:x}, hi: 0x{:x} }}", self.lo, self.hi)
+    }
+    #[cfg(not(debug_assertions))]
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "Bounds {{ <optimised out> }}")
+    }
+}


### PR DESCRIPTION
This is a somewhat large patch and it may not be in the best form as written (totally happy to tweak/change/rebase as required etc.), but it picks several possible problems (including #47) and seems to have essentially no overhead in release mode. Also, the patch isn't *that* large: the majority of the change is adding the `limb_ptr` module, and the mechanical changes to type signatures in `ll` and to the right accessor methods on `Int`.

Introduce the ramp::ll::limb_ptr::{LimbPtr, LimbPtrMut} types which are essentially equivalent to `*const Limb` and `*mut Limb`, except they perform bounds checking in debug mode, i.e. if debug_assertions are enabled, then dereferencing and .offset'ing will check to ensure that the access is happening within the allocation they're meant to. These types expose a very similar API to raw pointers (at least, the parts ramp uses), e.g. `offset(isize)`, comparisons that use the raw pointer value, and dereferencing. (The latter isn't/can't be `unsafe` with `LimbPtr`, which means they're not quite a drop-in replacement.)

I've tried to keep the API as close as possible to raw pointers so that theoretically `LimbPtr` could just be `type LimbPtr = *const Limb;` in release mode to truly have zero overhead, but I suspect inability to make deref  `unsafe` means getting them to match exactly is impossible. Hence, it may be nicer to move away from the raw pointer API, e.g. change `offset` to take `i32` instead of `isize`.

(The individual commit messages have more details, especially the first one.)
