### PR TITLE
Optimise `ll::base::num_base_digits` for 2 & other powers of it.

### DIFF
--- a/src/ll/base.rs
+++ b/src/ll/base.rs
@@ -54,9 +54,15 @@ pub unsafe fn num_base_digits(p: Limbs, n: i32, base: u32) -> usize {
     let cnt = (*p.offset((n - 1) as isize)).leading_zeros() as usize;
     let total_bits = (Limb::BITS * (n as usize)) - cnt;
 
-    if base.is_power_of_two() {
+    if base == 2 {
+        // no need to do anything complicated here at all, so let's go
+        // as fast as possible (this is a somewhat common case, due to
+        // `bit_length`)
+        total_bits
+    } else if base.is_power_of_two() {
         let big_base = BASES.get_unchecked(base as usize).big_base.0 as usize;
-        (total_bits + big_base - 1) / big_base
+        // doing an actual division here is much slower than this
+        (total_bits + big_base - 1) >> big_base.trailing_zeros()
     } else {
         // Not sure if using floating-point arithmetic here is the best idea,
         // but it should be a reasonable accurate result, maybe a little high


### PR DESCRIPTION
The old code would end up with an actual division when inlined into
another crate, because the `BASES` symbol isn't inlined and hence the
compiler can't tell that the division will be by a power of two. This
caused `bit_length` to be very high in the profiles of my `float` crate
with the `div` instruction taking the majority of the time. It's
especially unfortunate because the divison for `bit_length` is a
division by 1.

(A simple benchmark of `Int::bit_length` shows the performance dropping
from 9 ns/iter to 1-2 ns/iter, with `div` taking ~80% of the time in the
former case.)

cc #52