### PR TITLE
From and to bytes

### DIFF
--- a/examples/pidigits.rs
+++ b/examples/pidigits.rs
@@ -1,8 +1,6 @@
 // A ramp port of TeXitoi's Rust version on
 // http://benchmarksgame.alioth.debian.org/
 
-#![feature(augmented_assignments)]
-
 extern crate ramp;
 use ramp::Int;
 use ramp::ll::limb::Limb;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,8 +16,7 @@
 #![crate_name="ramp"]
 
 #![feature(core_intrinsics, asm, heap_api, associated_consts)]
-#![feature(zero_one, step_trait, unique, alloc, op_assign_traits)]
-#![feature(augmented_assignments)]
+#![feature(zero_one, step_trait, unique, alloc)]
 
 #![cfg_attr(test, feature(test))]
 

--- a/tests/quickcheck.rs
+++ b/tests/quickcheck.rs
@@ -763,7 +763,7 @@ fn from_u8_radix(a: BigIntStr, b: u8) -> TestResult {
         assert_eq!(0, *b); // not written bytes
     }
 
-    let back = Int::from_u8_radix(&buf[0..bytes_written], b).unwrap();
+    let back = Int::from_u8_be_radix(&buf[0..bytes_written], b).unwrap();
 
     assert_eq!(back, ar.abs());
 

--- a/tests/quickcheck.rs
+++ b/tests/quickcheck.rs
@@ -745,6 +745,31 @@ fn from_str_decimal(a: BigIntStr) {
     assert_eq!(sr2, ar);
 }
 
+#[quickcheck]
+fn from_u8_radix(a: BigIntStr, b: u8) -> TestResult {
+    if b < 2 || b == 255 { return TestResult::discard() }
+
+    let (ar, _) = a.parse();
+
+    let mut buf : Vec<u8> = vec![0; 1000];
+
+    let result = ar.write_u8_be_radix(&mut buf[..], b);
+    let bytes_written = match result {
+        Err(_) => return TestResult::discard(),
+        Ok(bytes) => bytes
+    };
+
+    for b in &buf[bytes_written..] {
+        assert_eq!(0, *b); // not written bytes
+    }
+
+    let back = Int::from_u8_radix(&buf[0..bytes_written], b).unwrap();
+
+    assert_eq!(back, ar.abs());
+
+    TestResult::passed()
+}
+
 mod format {
     use ::BigIntStr;
 

--- a/tests/quickcheck.rs
+++ b/tests/quickcheck.rs
@@ -1,5 +1,3 @@
-#![feature(augmented_assignments)]
-
 #![feature(plugin)]
 #![plugin(quickcheck_macros)]
 


### PR DESCRIPTION
Added Functions:

```
Int:
    pub fn estimate_num_base_digits(&self, base: u8) -> usize {
    pub fn minimal_buffer_size(&self) -> usize {
    pub fn write_u8_be_radix(&self, dst : &mut [u8], base : u8) -> Result<usize, BufferToSmallError>  {
    pub fn write_radix_callback<F: FnMut(u8)>(&self, base : u8, receiver: F) {
    pub fn write_big_endian_buffer(&self, dst : &mut [u8]) -> Result<usize, BufferToSmallError> {
    pub fn write_big_endian_buffer_align(&self, dst : &mut [u8]) -> Result<usize, BufferToSmallError> {
    pub unsafe fn from_u8_be_radix_unchecked(src: &[u8], base : u8) -> Result<Int, ParseIntError> {
    pub fn from_u8_be_radix(src: &[u8], base : u8) -> Result<Int, ParseIntError> {
    pub fn from_big_endian_slice(src: &[u8]) -> Int {
    pub fn leading_zeros(&self) -> u32 {

    fn iter<'a>(&'a self) -> LimbsIteratorState<'a> {
Limb:
    pub unsafe fn iter_raw_bytes<'a>(&'a self) -> LimbRawBytesIteratorState<'a> {
```
The iterators for the limbs may not be performant, but
they are only used in write_big_endian_buffer() if the target is a big endian system, and this functionality is untested because I do not have a big endian system and will panic! on big endian.

Lets discuss :)
#6 