### PR TITLE
Bump version number

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ramp"
 description = "A high-performance multiple-precision arithmetic library"
-version = "0.2.4"
+version = "0.2.5"
 authors = ["James Miller <james@aatch.net>"]
 build = "build.rs"
 license = "Apache-2.0"


### PR DESCRIPTION
0.2.4, depending on the commit, will not compile in nightly or stable