### PR TITLE
Use num_traits instead of std::num.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ full-quickcheck = []
 ieee754 = "0.2"
 rand = "0.3"
 hamming = "0.1"
+num-traits = "0.1.35"
 
 [build-dependencies]
 gcc = "0.3"

--- a/examples/pidigits.rs
+++ b/examples/pidigits.rs
@@ -1,8 +1,6 @@
 // A ramp port of TeXitoi's Rust version on
 // http://benchmarksgame.alioth.debian.org/
 
-#![feature(augmented_assignments)]
-
 extern crate ramp;
 use ramp::Int;
 use ramp::ll::limb::Limb;

--- a/src/int.rs
+++ b/src/int.rs
@@ -20,7 +20,6 @@ use std::cmp::{
 };
 use std::error::Error;
 use std::{io, mem, fmt, hash};
-use std::num::Zero;
 use std::ops::{
     Add, Sub, Mul, Div, Rem, Neg,
     AddAssign, SubAssign, MulAssign, DivAssign, RemAssign,
@@ -33,6 +32,7 @@ use rand::Rng;
 
 use hamming;
 use alloc;
+use num_traits::{Zero, One};
 
 use ll;
 use ll::limb::{BaseInt, Limb};
@@ -129,7 +129,7 @@ impl Int {
     }
 
     pub fn one() -> Int {
-        <Int as std::num::One>::one()
+        <Int as One>::one()
     }
 
     /// Creates a new Int from the given Limb.
@@ -3531,7 +3531,7 @@ macro_rules! impl_from_for_prim (
 impl_from_for_prim!(signed   i8, i16, i32, i64, isize);
 impl_from_for_prim!(unsigned u8, u16, u32, u64, usize);
 
-impl std::num::Zero for Int {
+impl Zero for Int {
     fn zero() -> Int {
         Int {
             ptr: unsafe { Unique::new(alloc::heap::EMPTY as *mut Limb) },
@@ -3539,9 +3539,13 @@ impl std::num::Zero for Int {
             cap: 0
         }
     }
+
+    fn is_zero(&self) -> bool {
+        self.sign() == 0
+    }
 }
 
-impl std::num::One for Int {
+impl One for Int {
     fn one() -> Int {
         Int::from(1)
     }
@@ -3710,7 +3714,6 @@ mod test {
     use ll::limb::Limb;
     use traits::DivRem;
     use std::str::FromStr;
-    use std::num::Zero;
 
     macro_rules! assert_mp_eq (
         ($l:expr, $r:expr) => (

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,7 @@
 #![crate_name="ramp"]
 
 #![feature(core_intrinsics, asm, heap_api, associated_consts)]
-#![feature(zero_one, step_trait, unique, alloc)]
+#![feature(step_trait, unique, alloc)]
 
 #![cfg_attr(test, feature(test))]
 
@@ -26,6 +26,7 @@ extern crate alloc;
 extern crate ieee754;
 extern crate rand;
 extern crate hamming;
+extern crate num_traits;
 
 pub mod ll;
 mod mem;

--- a/src/rational.rs
+++ b/src/rational.rs
@@ -892,7 +892,7 @@ mod test {
     use super::*;
     use ll::limb::Limb;
     use std::str::FromStr;
-    use std::num::Zero;
+    use num_traits::Zero;
 
     use std::cmp::Ordering;
 

--- a/tests/quickcheck.rs
+++ b/tests/quickcheck.rs
@@ -1,5 +1,3 @@
-#![feature(augmented_assignments)]
-
 #![feature(plugin)]
 #![plugin(quickcheck_macros)]
 


### PR DESCRIPTION
>Also augmented_assignments is stable now.

Dunno if there's any sort of conformance tests for `num_traits` but I suppose since this adds a new method it should get a new test too?