### PR TITLE
Int: implement num_traits::Num, num_integer::Integer

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ ieee754 = "0.2"
 rand = "0.3"
 hamming = "0.1"
 num-traits = "0.1.35"
+num-integer = "0.1.32"
 rust-gmp = { version = "0.2", optional = true }
 
 [build-dependencies]
@@ -36,6 +37,5 @@ gcc = "0.3"
 
 [dev-dependencies]
 num-bigint = "*"
-num-integer = "*"
 quickcheck = "0.4.1"
 quickcheck_macros = "0.4.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,5 +37,5 @@ gcc = "0.3"
 [dev-dependencies]
 num-bigint = "*"
 num-integer = "*"
-quickcheck = "0.4"
-quickcheck_macros = "0.2"
+quickcheck = "0.4.1"
+quickcheck_macros = "0.4.1"

--- a/src/int.rs
+++ b/src/int.rs
@@ -32,6 +32,7 @@ use rand::Rng;
 
 use hamming;
 use alloc;
+use num_integer::Integer;
 use num_traits::{Num, Zero, One};
 
 use ll;
@@ -3557,6 +3558,53 @@ impl Num for Int {
     #[inline]
     fn from_str_radix(src: &str, radix: u32) -> Result<Int, ParseIntError> {
         Int::from_str_radix(src, radix as u8)
+    }
+}
+
+impl Integer for Int {
+    #[inline]
+    fn div_floor(&self, other: &Int) -> Int {
+        self / other
+    }
+
+    #[inline]
+    fn mod_floor(&self, other: &Int) -> Int {
+        self % other
+    }
+
+    #[inline]
+    fn gcd(&self, other: &Int) -> Int {
+        self.gcd(other)
+    }
+
+    #[inline]
+    fn lcm(&self, other: &Int) -> Int {
+        self.lcm(other)
+    }
+
+    #[inline]
+    fn divides(&self, other: &Int) -> bool {
+        other.is_multiple_of(self)
+    }
+
+    #[inline]
+    fn is_multiple_of(&self, other: &Int) -> bool {
+        (self % other).is_zero()
+    }
+
+    #[inline]
+    fn is_even(&self) -> bool {
+        self.is_even()
+    }
+
+    #[inline]
+    fn is_odd(&self) -> bool {
+        !self.is_even()
+    }
+
+    #[inline]
+    fn div_rem(&self, other: &Int) -> (Int, Int) {
+        self.divrem(other)
     }
 }
 

--- a/src/int.rs
+++ b/src/int.rs
@@ -32,7 +32,7 @@ use rand::Rng;
 
 use hamming;
 use alloc;
-use num_traits::{Zero, One};
+use num_traits::{Num, Zero, One};
 
 use ll;
 use ll::limb::{BaseInt, Limb};
@@ -3548,6 +3548,15 @@ impl Zero for Int {
 impl One for Int {
     fn one() -> Int {
         Int::from(1)
+    }
+}
+
+impl Num for Int {
+    type FromStrRadixErr = ParseIntError;
+
+    #[inline]
+    fn from_str_radix(src: &str, radix: u32) -> Result<Int, ParseIntError> {
+        Int::from_str_radix(src, radix as u8)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,6 +26,7 @@ extern crate alloc;
 extern crate ieee754;
 extern crate rand;
 extern crate hamming;
+extern crate num_integer;
 extern crate num_traits;
 
 pub mod ll;


### PR DESCRIPTION
This allows one to benchmark `num_rational::Rational<ramp::int::Int>` against `ramp::rational::Rational`.