### PR TITLE
Fix tests (update quickcheck to 0.4.1)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,5 +37,5 @@ gcc = "0.3"
 [dev-dependencies]
 num-bigint = "*"
 num-integer = "*"
-quickcheck = "0.4"
-quickcheck_macros = "0.2"
+quickcheck = "0.4.1"
+quickcheck_macros = "0.4.1"


### PR DESCRIPTION
I fixed quickcheck_macros for current Rust nightly (BurntSushi/quickcheck#153); use the fixed version so the tests pass again.