### PR TITLE
Fix deprecation warnings about SipHasher vs DefaultHasher

### DIFF
--- a/src/int.rs
+++ b/src/int.rs
@@ -4439,11 +4439,11 @@ mod test {
 
             assert!(x1 == x2);
 
-            let mut hasher = std::hash::SipHasher::new();
+            let mut hasher = std::collections::hash_map::DefaultHasher::new();
             x1.hash(&mut hasher);
             let x1_hash = hasher.finish();
 
-            let mut hasher = std::hash::SipHasher::new();
+            let mut hasher = std::collections::hash_map::DefaultHasher::new();
             x2.hash(&mut hasher);
             let x2_hash = hasher.finish();
 


### PR DESCRIPTION
Currently, building gives the warning messages:
```
warning: use of deprecated item: use `std::collections::hash_map::DefaultHasher` instead, #[warn(deprecated)] on by default
    --> src/int.rs:4442:30
     |
4442 |             let mut hasher = std::hash::SipHasher::new();
     |                              ^^^^^^^^^^^^^^^^^^^^^^^^^

warning: use of deprecated item: use `std::collections::hash_map::DefaultHasher` instead, #[warn(deprecated)] on by default
    --> src/int.rs:4442:30
     |
4442 |             let mut hasher = std::hash::SipHasher::new();
     |                              ^^^^^^^^^^^^^^^^^^^^^^^^^

warning: use of deprecated item: use `std::collections::hash_map::DefaultHasher` instead, #[warn(deprecated)] on by default
    --> src/int.rs:4446:30
     |
4446 |             let mut hasher = std::hash::SipHasher::new();
     |                              ^^^^^^^^^^^^^^^^^^^^^^^^^

warning: use of deprecated item: use `std::collections::hash_map::DefaultHasher` instead, #[warn(deprecated)] on by default
    --> src/int.rs:4446:30
     |
4446 |             let mut hasher = std::hash::SipHasher::new();
     |                              ^^^^^^^^^^^^^^^^^^^^^^^^^

    Finished release [optimized] target(s) in 94.5 secs
     Running target/release/deps/quickcheck-5d65a93dfbfec02c
```