### PR TITLE
Now compiles on latest nightly; also testing fixes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ramp"
 description = "A high-performance multiple-precision arithmetic library"
-version = "0.3.3"
+version = "0.3.4"
 authors = ["James Miller <james@aatch.net>"]
 build = "build.rs"
 license = "Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ramp"
 description = "A high-performance multiple-precision arithmetic library"
-version = "0.3.4"
+version = "0.3.5"
 authors = ["James Miller <james@aatch.net>"]
 build = "build.rs"
 license = "Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ramp"
 description = "A high-performance multiple-precision arithmetic library"
-version = "0.3.5"
+version = "0.3.6"
 authors = ["James Miller <james@aatch.net>"]
 build = "build.rs"
 license = "Apache-2.0"

--- a/src/int.rs
+++ b/src/int.rs
@@ -4552,7 +4552,7 @@ mod test {
     #[test]
     fn add_larger_limb() {
         let a = Int::from(-14);
-        let b = Limb(15u64);
+        let b = Limb(15 as BaseInt);
         assert_eq!(a + b, Int::one());
     }
 

--- a/src/int.rs
+++ b/src/int.rs
@@ -3613,16 +3613,8 @@ impl Integer for Int {
 }
 
 impl std::iter::Step for Int {
-    fn step(&self, by: &Int) -> Option<Int> {
-        Some(self + by)
-    }
-
-    fn steps_between(start: &Int, end: &Int, by: &Int) -> Option<usize> {
-        if by.le(&0) { return None; }
-        let mut diff = (start - end).abs();
-        if by.ne(&1) {
-            diff = diff / by;
-        }
+    fn steps_between(start: &Int, end: &Int) -> Option<usize> {
+        let diff = (start - end).abs();
 
         // Check to see if result fits in a usize
         if diff > !0usize {
@@ -3630,14 +3622,6 @@ impl std::iter::Step for Int {
         } else {
             Some(usize::from(&diff))
         }
-    }
-
-    fn steps_between_by_one(start: &Self, end: &Self) -> Option<usize> {
-        Self::steps_between(start, end, &Self::one())
-    }
-
-    fn is_negative(&self) -> bool {
-        self.sign() < 0
     }
 
     fn replace_one(&mut self) -> Self {
@@ -3654,6 +3638,10 @@ impl std::iter::Step for Int {
 
     fn sub_one(&self) -> Self {
         self - 1
+    }
+
+    fn add_usize(&self, n: usize) -> Option<Self> {
+        Some(self + Int::from(n))
     }
 }
 
@@ -4343,6 +4331,20 @@ mod test {
 
         let i = Int::from(::std::usize::MAX);
         assert_eq!(usize::from(&i), ::std::usize::MAX);
+    }
+
+    #[test]
+    fn step() {
+        use std::iter::Step;
+
+        let a = Int::from(897235032);
+        let b = Int::from(98345);
+
+        assert_eq!(Int::steps_between(&a, &b), Some(897136687));
+        assert_eq!(Int::steps_between(&a, &b), Int::steps_between(&b, &a));
+        assert_eq!(a.add_one(), Int::from(897235033));
+        assert_eq!(a.sub_one(), Int::from(897235031));
+        assert_eq!(a.add_usize(232184), Some(Int::from(897467216)));
     }
 
     const RAND_ITER : usize = 1000;

--- a/src/int.rs
+++ b/src/int.rs
@@ -263,7 +263,7 @@ impl Int {
                 let l = *ptr;
                 l.hash(state);
 
-                ptr = ptr.offset(2);
+                ptr = ptr.offset(1);
                 size -= 1;
             }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,7 @@
 #![crate_type="lib"]
 #![crate_name="ramp"]
 
-#![feature(core_intrinsics, asm, heap_api, associated_consts)]
+#![feature(core_intrinsics, asm, allocator_api)]
 #![feature(step_trait, unique, alloc)]
 
 #![cfg_attr(test, feature(test))]


### PR DESCRIPTION
The hashing method for `Int` depended on the limb representation, which meant that the hashes of two equal numbers weren't necessarily equal. The simple fix was to normalize before hashing. Unfortunately this copies the `Int`, but I think it's the only way to go here.