### PR TITLE
Changed from deprecated crate gcc-rs to cc-rs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ rust-gmp = { version = "0.2", optional = true }
 [build-dependencies]
 num-bigint = "0.1"
 rustc-cfg = "0.2"
-gcc = "0.3"
+cc = "1.0.0"
 
 [dev-dependencies]
 num-bigint = "0.1"

--- a/build.rs
+++ b/build.rs
@@ -1,6 +1,6 @@
 #![allow(unused_must_use)]
 
-extern crate gcc;
+extern crate cc;
 extern crate rustc_cfg;
 extern crate num_bigint;
 
@@ -34,13 +34,12 @@ fn compile_asm() {
             // Currently only supported for 64-bit linux
             if (target.contains("x86-64") || target.contains("x86_64")) && target.contains("linux")  {
 
-                let asm_srcs = &[
-                    "src/ll/asm/addsub_n.S",
-                    "src/ll/asm/mul_1.S",
-                    "src/ll/asm/addmul_1.S",
-                ];
+                cc::Build::new()
+                    .file("src/ll/asm/addsub_n.S")
+                    .file("src/ll/asm/mul_1.S")
+                    .file("src/ll/asm/addmul_1.S")
+                    .compile("libasm");
 
-                gcc::compile_library("libasm.a", asm_srcs);
                 // Use a cfg param so turning the feature on when we don't have
                 // asm impls available doesn't cause compile errors
                 println!("cargo:rustc-cfg=asm");


### PR DESCRIPTION
All tests pass as well:
```
running 121 tests
[...]
test result: ok. 121 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

running 243 tests
[...]
test result: ok. 243 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out


running 4 tests
[...]
test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

running 5 tests
test src\int.rs - int::Int (line 60) ... ok
test src\int.rs - int::Int (line 103) ... ok
test src\int.rs - int::Int (line 67) ... ok
test src\int.rs - int::Int (line 80) ... ok
test src\int.rs - int::RandomInt (line 3664) ... ok

test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```