### PR TITLE
Use `slice::iter` instead of `into_iter` to avoid future breakage

### DIFF
--- a/src/int.rs
+++ b/src/int.rs
@@ -4264,7 +4264,7 @@ mod test {
              "100000000000000000000000000000000000000000000000"),
         ];
 
-        for t in cases.into_iter() {
+        for t in cases.iter() {
             let dividend: Int = t.0.parse().unwrap();
             let divisor: Int = t.1.parse().unwrap();
             let expected_quotient: Int = t.2.parse().unwrap();

--- a/src/rational.rs
+++ b/src/rational.rs
@@ -1134,7 +1134,7 @@ mod test {
             ("1337/-1337", "-1337/-1337")
         };
 
-        for &(ref r, ref l) in cases.into_iter() {
+        for &(ref r, ref l) in cases.iter() {
             assert_eq!(&r.clone().abs(), l);
         }
     }


### PR DESCRIPTION
`an_array.into_iter()` currently just works because of the autoref
feature, which then calls `<[T] as IntoIterator>::into_iter`. But
in the future, arrays will implement `IntoIterator`, too. In order
to avoid problems in the future, the call is replaced by `iter()`
which is shorter and more explicit.

A crater run showed that your crate is affected by a potential future 
change. See https://github.com/rust-lang/rust/pull/65819 for more information.