### PR TITLE
Remove the word "trailing" from Int::count_ones()

### DIFF
--- a/src/int.rs
+++ b/src/int.rs
@@ -12,6 +12,8 @@
 //    See the License for the specific language governing permissions and
 //    limitations under the License.
 
+//! This module holds `Int` and related types.
+
 use std;
 use std::cmp::{
     Ordering,
@@ -42,81 +44,79 @@ use alloc::raw_vec::RawVec;
 
 use traits::DivRem;
 
-/**
- * An arbitrary-precision signed integer.
- *
- * This type grows to the size it needs to in order to store the result of any operation.
- *
- * ## Creation
- *
- * An `Int` can be constructed in a number of ways:
- *
- * - `Int::zero` and `Int::one` construct a zero- and one-valued `Int` respectively.
- *
- * - `Int::from` will convert from any primitive integer type to an `Int` of the same value
- *
- *   ```
- *   # use ramp::Int;
- *   let four = Int::from(4);
- *   ```
- *
- * - `Int::from_str` (or `str::parse`) will attempt to convert from a string to an `Int`
- *
- *   ```
- *   # use ramp::Int;
- *   # use std::str::FromStr;
- *   let i = Int::from_str("123456789").unwrap();
- *   ```
- *
- * ## Output
- *
- * `Int` supports all the formatting traits, allowing it to be used just like a regular integer
- * when used in `format!` and similar macros. `Int` also supports conversion to primitive integer
- * types, truncating if the `Int` cannot fit into the target type. Conversion to primtive integers
- * is done with the `From` trait:
- *
- *   ```
- *   # use ramp::Int;
- *   let big_i   = Int::from(123456789);
- *   let i = i32::from(&big_i);
- *   assert_eq!(123456789, i);
- *   ```
- *
- * ## Usage
- *
- * `Int` has a number of operator overloads to make working with them as painless as possible.
- *
- * The most basic usage is simply `a + b` or similar. Assuming `a` and `b` are of type `Int`, this
- * operation will consume both operands, reusing the storage from one of them. If you do not wish
- * your operands to be moved, one or both of them can be references: `&a + &b` works as well, but
- * requires an entire new `Int` to be allocated for the return value.
- *
- * There are also a overloads for a small number of primitive integer types, namely `i32` and
- * `usize`. While automatic type widening isn't done in Rust in general, many operations are much
- * more efficient when working with a single integer. This means you can do `a + 1` knowing that it
- * will be performed as efficiently as possible. Comparison with these integer types is also
- * possible, allowing checks for small constant values to be done easily:
- *
- *   ```
- *   # use ramp::Int;
- *   let big_i   = Int::from(123456789);
- *   assert!(big_i == 123456789);
- *   ```
- *
- * ### Semantics
- *
- * Addition, subtraction and multiplication follow the expected rules for integers. Division of two
- * integers, `N / D` is defined as producing two values: a quotient, `Q`, and a remainder, `R`,
- * such that the following equation holds: `N = Q*D + R`. The division operator itself returns `Q`
- * while the remainder/modulo operator returns `R`. The sign of `R` is the same as the sign of `Q`.
- *
- * The "bit-shift" operations are defined as being multiplication and division by a power-of-two for
- * shift-left and shift-right respectively. The sign of the number is unaffected.
- *
- * The remaining bitwise operands act as if the numbers are stored in two's complement format and as
- * if the two inputs have the same number of bits.
- *
- */
+///
+/// An arbitrary-precision signed integer.
+///
+/// This type grows to the size it needs to in order to store the result of any operation.
+///
+/// ## Creation
+///
+/// An `Int` can be constructed in a number of ways:
+///
+/// - `Int::zero` and `Int::one` construct a zero- and one-valued `Int` respectively.
+///
+/// - `Int::from` will convert from any primitive integer type to an `Int` of the same value
+///
+///   ```
+///   # use ramp::Int;
+///   let four = Int::from(4);
+///   ```
+///
+/// - `Int::from_str` (or `str::parse`) will attempt to convert from a string to an `Int`
+///
+///   ```
+///   # use ramp::Int;
+///   # use std::str::FromStr;
+///   let i = Int::from_str("123456789").unwrap();
+///   ```
+///
+/// ## Output
+///
+/// `Int` supports all the formatting traits, allowing it to be used just like a regular integer
+/// when used in `format!` and similar macros. `Int` also supports conversion to primitive integer
+/// types, truncating if the `Int` cannot fit into the target type. Conversion to primtive integers
+/// is done with the `From` trait:
+///
+///   ```
+///   # use ramp::Int;
+///   let big_i   = Int::from(123456789);
+///   let i = i32::from(&big_i);
+///   assert_eq!(123456789, i);
+///   ```
+///
+/// ## Usage
+///
+/// `Int` has a number of operator overloads to make working with them as painless as possible.
+///
+/// The most basic usage is simply `a + b` or similar. Assuming `a` and `b` are of type `Int`, this
+/// operation will consume both operands, reusing the storage from one of them. If you do not wish
+/// your operands to be moved, one or both of them can be references: `&a + &b` works as well, but
+/// requires an entire new `Int` to be allocated for the return value.
+///
+/// There are also a overloads for a small number of primitive integer types, namely `i32` and
+/// `usize`. While automatic type widening isn't done in Rust in general, many operations are much
+/// more efficient when working with a single integer. This means you can do `a + 1` knowing that it
+/// will be performed as efficiently as possible. Comparison with these integer types is also
+/// possible, allowing checks for small constant values to be done easily:
+///
+///   ```
+///   # use ramp::Int;
+///   let big_i   = Int::from(123456789);
+///   assert!(big_i == 123456789);
+///   ```
+///
+/// ### Semantics
+///
+/// Addition, subtraction and multiplication follow the expected rules for integers. Division of two
+/// integers, `N / D` is defined as producing two values: a quotient, `Q`, and a remainder, `R`,
+/// such that the following equation holds: `N = Q*D + R`. The division operator itself returns `Q`
+/// while the remainder/modulo operator returns `R`. The sign of `R` is the same as the sign of `Q`.
+///
+/// The "bit-shift" operations are defined as being multiplication and division by a power-of-two for
+/// shift-left and shift-right respectively. The sign of the number is unaffected.
+///
+/// The remaining bitwise operands act as if the numbers are stored in two's complement format and as
+/// if the two inputs have the same number of bits.
 pub struct Int {
     ptr: Unique<Limb>,
     size: i32,
@@ -124,15 +124,19 @@ pub struct Int {
 }
 
 impl Int {
+    /// Creates the `Int` that represents zero.
     pub fn zero() -> Int {
         <Int as Zero>::zero()
     }
 
+    /// Creates the `Int` that represents one.
     pub fn one() -> Int {
         <Int as One>::one()
     }
 
-    /// Creates a new Int from the given Limb.
+    /// Creates an `Int` from a single [`Limb`]
+    ///
+    /// [`Limb`]: ../ll/limb/struct.Limb.html
     pub fn from_single_limb(limb: Limb) -> Int {
         let mut i = Int::with_capacity(1);
         unsafe {
@@ -143,10 +147,8 @@ impl Int {
         i
     }
 
-    /**
-     * Views the internal memory as a `RawVec`, which can be
-     * manipulated to change `self`'s allocation.
-     */
+    /// Passes a `RawVec` version of this `Int`, which can be manipulated to alter this `Int`'s
+    /// allocation.
     fn with_raw_vec<F: FnOnce(&mut RawVec<Limb>)>(&mut self, f: F) {
         unsafe {
             let old_cap = self.cap as usize;
@@ -177,6 +179,7 @@ impl Int {
         }
     }
 
+    /// Creates an `Int` with the given capacity.
     fn with_capacity(cap: u32) -> Int {
         let mut ret = Int::zero();
         if cap != 0 {
@@ -185,10 +188,8 @@ impl Int {
         ret
     }
 
-    /**
-     * Returns the sign of the Int as either -1, 0 or 1 for self being negative, zero
-     * or positive, respectively.
-     */
+    /// Returns the sign of this `Int` as either -1, 0 or 1 depending on whether it is negative,
+    /// zero, or positive, respectively.
     #[inline(always)]
     pub fn sign(&self) -> i32 {
         if self.size == 0 {
@@ -200,18 +201,16 @@ impl Int {
         }
     }
 
-    /**
-     * Consumes self and returns the absolute value
-     */
+    /// Consumes this `Int` and returns its absolute value.
     #[inline]
     pub fn abs(mut self) -> Int {
         self.size = self.size.abs();
         self
     }
 
-    /**
-     * Returns the least-significant limb of self.
-     */
+    /// Returns the least-significant [`Limb`] of this `Int`.
+    ///
+    /// [`Limb`]: ../ll/limb/struct.Limb.html
     #[inline]
     pub fn to_single_limb(&self) -> Limb {
         if self.sign() == 0 {
@@ -221,15 +220,13 @@ impl Int {
         }
     }
 
+    /// Gets the absolute value of this `Int`'s size.
     #[inline(always)]
     fn abs_size(&self) -> i32 {
         self.size.abs()
     }
 
-    /**
-     * Compare the absolute value of self to the absolute value of other,
-     * returning an Ordering with the result.
-     */
+    /// Compares the absolute value of this `Int` with the absolute value of another.
     pub fn abs_cmp(&self, other: &Int) -> Ordering {
         if self.abs_size() > other.abs_size() {
             Ordering::Greater
@@ -242,19 +239,15 @@ impl Int {
         }
     }
 
-    /**
-     * Returns the equality of the absolute values of self and
-     * other.
-     */
+    /// Returns whether this `Int` has the same absolute value as another.
     pub fn abs_eq(&self, other: &Int) -> bool {
         self.abs_cmp(other) == Ordering::Equal
     }
 
-    /**
-     * Hashes the value without including the sign, useful for when the
-     * sign is handled elsewhere and making a copy just to change the sign
-     * is wasteful
-     */
+    /// Hashes the value without including the sign.
+    ///
+    /// This is useful for when the sign is handled elsewhere and making a copy just to change the
+    /// sign is wasteful.
     pub fn abs_hash<H>(&self, state: &mut H) where H: hash::Hasher {
         use std::hash::Hash;
         let mut size = self.abs_size();
@@ -270,9 +263,7 @@ impl Int {
         }
     }
 
-    /**
-     * Try to shrink the allocated data for this Int.
-     */
+    /// Shrinks the allocated data for this `Int`, attempting to remove excess capacity.
     pub fn shrink_to_fit(&mut self) {
         let mut size = self.abs_size() as usize;
 
@@ -285,12 +276,14 @@ impl Int {
         })
     }
 
-    /**
-     * Returns a string containing the value of self in base `base`. For bases greater than
-     * ten, if `upper` is true, upper-case letters are used, otherwise lower-case ones are used.
-     *
-     * Panics if `base` is less than two or greater than 36.
-     */
+    /// Creates a string containing the value of this `Int` in base `base`.
+    ///
+    /// For bases greater than ten, if `upper` is true, upper-case letters are used; otherwise,
+    /// lower-case letters are used.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `base` is less than two or greater than 36.
     pub fn to_str_radix(&self, base: u8, upper: bool) -> String {
         if self.size == 0 {
             return "0".to_string();
@@ -316,6 +309,7 @@ impl Int {
         unsafe { String::from_utf8_unchecked(buf) }
     }
 
+    /// Similar to `to_str_radix`, writing to something that implements `io::Write` instead.
     pub fn write_radix<W: io::Write>(&self, w: &mut W, base: u8, upper: bool) -> io::Result<()> {
         debug_assert!(self.well_formed());
 
@@ -339,9 +333,7 @@ impl Int {
         Ok(())
     }
 
-    /**
-     * Creates a new Int from the given string in base `base`.
-     */
+    /// Creates a new Int from the given string in base `base`.
     pub fn from_str_radix(mut src: &str, base: u8) -> Result<Int, ParseIntError> {
         if base < 2 || base > 36 {
             panic!("Invalid base: {}", base);
@@ -390,14 +382,13 @@ impl Int {
         Ok(i)
     }
 
-    /**
-     * Divide self by other, returning the quotient, Q, and remainder, R as (Q, R).
-     *
-     * With N = self, D = other, Q and R satisfy: `N = QD + R`.
-     * The sign of `Q` and `R` are the same.
-     *
-     * This will panic if `other` is zero.
-     */
+    /// Divides this `Int` by `other`, returning the quotient `q` and the remainder `r` as `(q, r)`.
+    ///
+    /// This satisfies `self = q * other + r`, ensuring that `q` and `r` have the same sign.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `other` is zero.
     pub fn divmod(&self, other: &Int) -> (Int, Int) {
         debug_assert!(self.well_formed());
         debug_assert!(other.well_formed());
@@ -433,9 +424,7 @@ impl Int {
         (q, r)
     }
 
-    /**
-     * Raises self to the power of exp
-     */
+    /// Raises this `Int` to the power of `exp`.
     pub fn pow(&self, exp: usize) -> Int {
         debug_assert!(self.well_formed());
         match exp {
@@ -468,9 +457,7 @@ impl Int {
         }
     }
 
-    /**
-     * Returns the square of `self`.
-     */
+    /// Squares this `Int`.
     pub fn square(&self) -> Int {
         debug_assert!(self.well_formed());
         let s = self.sign();
@@ -498,7 +485,9 @@ impl Int {
         }
     }
 
-    // DESTRUCTIVE square. Is there a more idiomatic way of doing this?
+    /// Consumes this `Int` and returns its square.
+    ///
+    /// TODO: Is there a more idiomatic way of doing this?
     pub fn dsquare(mut self) -> Int {
         debug_assert!(self.well_formed());
         let s = self.sign();
@@ -519,13 +508,10 @@ impl Int {
         }
     }
 
-    /**
-     * Compute the sqrt of this number, returning its floor, S,  and the
-     * remainder, R, as Some((S, R)), or None if this number is negative.
-     *
-     * The numbers S, R are both positive and satisfy `self = S * S +
-     * R`.
-     */
+    /// Computes the nearest square root `s` of this number and its remainder `r` as
+    /// `Some((s, r))`, or `None` if this `Int` is negative.
+    ///
+    /// `s` and `r` are both positive and satisfy `self = s * s + r`.
     pub fn sqrt_rem(mut self) -> Option<(Int, Int)> {
         debug_assert!(self.well_formed());
 
@@ -577,29 +563,19 @@ impl Int {
         }
     }
 
-    /**
-     * Negates `self` in-place
-     */
+    /// Negates this `Int` in place.
     pub fn negate(&mut self) {
         self.size *= -1;
     }
 
-    /**
-     * Returns whether or not this number is even.
-     *
-     * Returns 0 if `self == 0`
-     */
+    /// Returns whether this `Int` is even.
     #[inline]
     pub fn is_even(&self) -> bool {
         debug_assert!(self.well_formed());
         (self.to_single_limb().0 & 1) == 0
     }
 
-    /**
-     * Returns the number of trailing zero bits in this number
-     *
-     * Returns 0 if `self == 0`
-     */
+    /// Returns the number of trailing zero bits for this `Int`, or zero if this `Int` is zero.
     #[inline]
     pub fn trailing_zeros(&self) -> u32 {
         debug_assert!(self.well_formed());
@@ -612,12 +588,10 @@ impl Int {
         }
     }
 
-    /**
-     * Returns the number of ones (the population count) in this number
-     *
-     * If this number is negative, it has infinitely many ones (in
-     * two's complement), so this returns usize::MAX.
-     */
+    /// Returns the number of trailing one bits (i.e. the population count) for this `Int`
+    ///
+    /// If this number is negative, it has infinitely many ones (in two's complement). Therefore,
+    /// this method returns `usize::MAX` for negative numbers.
     pub fn count_ones(&self) -> usize {
         debug_assert!(self.well_formed());
         if self.sign() < 0 {
@@ -631,12 +605,10 @@ impl Int {
         }
     }
 
-    /**
-     * Returns the number of bits required to represent (the absolute
-     * value of) this number, that is, `floor(log2(abs(self))) + 1`.
-     *
-     * Returns 1 if `self == 0`.
-     */
+    /// Returns the number of bits required to represent the absolute value of this `Int`, i.e.,
+    /// `floor(log2(abs(self))) + 1`.
+    ///
+    /// Returns one if this number is zero.
     #[inline]
     pub fn bit_length(&self) -> u32 {
         if *self == 0 {
@@ -648,10 +620,8 @@ impl Int {
         }
     }
 
-    /**
-     * Returns the value of the `bit`th bit in this number, as if it
-     * were represented in two's complement.
-     */
+    /// Returns the value of the `bit`th bit in this `Int`, as if it were represented in two's
+    /// complement.
     #[inline]
     pub fn bit(&self, bit: u32) -> bool {
         let word = (bit / Limb::BITS as u32) as isize;
@@ -678,10 +648,8 @@ impl Int {
         }
     }
 
-    /**
-     * Set the `bit`th bit of this number to `bit_val`, treating
-     * negative numbers as if they're stored in two's complement.
-     */
+    /// Sets the `bit`th bit of this number to `bit_val`, treating negative numbers as if they're
+    /// stored in two's complement.
     pub fn set_bit(&mut self, bit: u32, bit_val: bool) {
         debug_assert!(self.well_formed());
         let word = bit / Limb::BITS as u32;
@@ -730,23 +698,26 @@ impl Int {
         self.normalize()
     }
 
-    // get a Limbs to all limbs currently initialised/in use
+    /// Gets the `Limbs` currently initialised or in use.
     fn limbs(&self) -> Limbs {
         unsafe {
             Limbs::new(self.ptr.as_ref(), 0, self.abs_size())
         }
     }
-    // get a LimbsMut to all limbs currently initialised/in use
+
+    /// Gets the `LimbsMut` currently initialised or in use.
     fn limbs_mut(&mut self) -> LimbsMut {
         unsafe {
             LimbsMut::new(self.ptr.as_mut(), 0, self.abs_size())
         }
     }
-    // get a LimbsMut to all allocated limbs
+
+    /// Gets the `LimbsMut` to all allocated limbs.
     unsafe fn limbs_uninit(&mut self) -> LimbsMut {
         LimbsMut::new(self.ptr.as_mut(), 0, self.cap as i32)
     }
 
+    /// Ensures that the `Int` has at least the given capacity.
     fn ensure_capacity(&mut self, cap: u32) {
         if cap > self.cap {
             let old_cap = self.cap as usize;
@@ -756,6 +727,7 @@ impl Int {
         }
     }
 
+    /// Pushes a `Limb` onto this `Int`.
     fn push(&mut self, limb: Limb) {
         let new_size = (self.abs_size() + 1) as u32;
         self.ensure_capacity(new_size);
@@ -772,9 +744,7 @@ impl Int {
         }
     }
 
-    /**
-     * Adjust the size field so the most significant limb is non-zero
-     */
+    /// Adjusts the size field so that the most-significant `Limb` is non-zero.
     fn normalize(&mut self) {
         if self.size == 0 { return }
         let sign = self.sign();
@@ -788,10 +758,8 @@ impl Int {
         debug_assert!(self.well_formed());
     }
 
-    /**
-     * Make sure the Int is "well-formed", i.e. that the size doesn't exceed the
-     * the capacity and that the most significant limb is non-zero
-     */
+    /// Returns whether the `Int` is well-formed, i.e. that the size doesn't exceed the capacity and
+    /// that the most significant `Limb` is non-zero.
     fn well_formed(&self) -> bool {
         if self.size == 0 { return true; }
 
@@ -806,10 +774,7 @@ impl Int {
         return high_limb != 0;
     }
 
-    /**
-     * convert self into two's complement format (i.e. *self =
-     * (!*self) + 1)
-     */
+    /// Negates this `Int` using two's complement, i.e. `!self + 1`.
     fn negate_twos_complement(&mut self) {
         unsafe {
             let self_ptr = self.limbs_mut();
@@ -821,7 +786,7 @@ impl Int {
         self.size = -self.size;
     }
 
-    /// Calculates the Greatest Common Divisor (GCD) of the number and `other`.
+    /// Computes the greates common divisor (GCD) of this `Int` and `other`.
     ///
     /// The result is always positive.
     #[inline]
@@ -854,12 +819,16 @@ impl Int {
         }
     }
 
-    /// Calculates the Lowest Common Multiple (LCM) of the number and `other`.
+    /// Computes the lowest common multiple (LCM) of this `Int` and `other`.
     #[inline]
     pub fn lcm(&self, other: &Int) -> Int {
         (self * other).abs() / self.gcd(other)
     }
 
+    /// Converts this `Int` into an `f64`.
+    ///
+    /// This is not an exact conversion, because this `Int` may be more precise than an `f64` can
+    /// account for.
     pub fn to_f64(&self) -> f64 {
         let sz = self.abs_size();
         if sz == 0 {
@@ -3445,8 +3414,9 @@ impl_fmt!(fmt::Debug,    10, "");
 impl_fmt!(fmt::LowerHex, 16, false, "0x");
 impl_fmt!(fmt::UpperHex, 16, true, "0x");
 
-// String parsing
-
+/// Error that arises when parsing an [`Int`].
+///
+/// [`Int`]: struct.Int.html
 #[derive(Debug, Clone, PartialEq)]
 pub struct ParseIntError { kind: ErrorKind }
 
@@ -3650,7 +3620,7 @@ impl std::iter::Step for Int {
     }
 }
 
-/// Trait for generating random `Int`.
+/// Trait for generating random `Int`s.
 ///
 /// # Example
 ///
@@ -3670,11 +3640,14 @@ impl std::iter::Step for Int {
 pub trait RandomInt {
     /// Generate a random unsigned `Int` of given bit size.
     fn gen_uint(&mut self, bits: usize) -> Int;
+
     /// Generate a random `Int` of given bit size.
     fn gen_int(&mut self, bits: usize) -> Int;
+
     /// Generate a random unsigned `Int` less than the given bound.
     /// Fails when the bound is zero or negative.
     fn gen_uint_below(&mut self, bound: &Int) -> Int;
+
     /// Generate a random `Int` within the given range.
     /// The lower bound is inclusive; the upper bound is exclusive.
     /// Fails when the upper bound is not greater than the lower bound.

--- a/src/ll/mod.rs
+++ b/src/ll/mod.rs
@@ -12,70 +12,68 @@
 //    See the License for the specific language governing permissions and
 //    limitations under the License.
 
-/*!
- * This module provides the low-level operations for working with arbitrary precision numbers.
- *
- * ## Overview
- *
- * This module forms the core of the library. As such, the functions are required to be highly
- * performant, even small inefficiencies can cause a large impact given how frequently some of
- * these functions are called. `addmul` for example is one of the most frequently called functions
- * in the library, so an efficiencies there will be multiplied out to almost the entire library.
- *
- * There are no real restrictions on the functions that can implemented in here. Exposed functions
- * should be generally useful to high-level code, but otherwise any operation that can be more
- * efficiently implemented here and then exposed by a higher-level API is a candidate.
- *
- * The functions in this module assume that all inputs are valid, though some checking is performed
- * in debug builds.
- *
- * ## Limbs
- *
- * A `Limb` is a single "digit" in an arbitrary-precision integer. To explain, consider the
- * standard base we work in, base-10. Base-10 uses represents numbers as a sequence of the digits
- * 0-9. The number 251 is 2 x 10^2 + 5 x 10^1 + 1 x 10^0. Similarly base-16 (hexadecimal) uses
- * sixteen digits and a base of 16 to represent numbers.
- *
- * A `Limb` is one word, with N bits (32 on a 32-bit platform, 64 on a 64-bit platform), so it can
- * represent 2^N unique values. It can therefore form the basis of a base-2^N number system. The
- * word "Limb" is used by GMP to distinguish it from a regular numerical digit, and there is no
- * obvious reason to use different terminology.
- *
- * `Limb` itself implements a number of useful methods. The basic mathematical operators are
- * implemented to provide wrapping behaviour by default. The most basic operations are also
- * implemented on `Limb`, notably multiplication with a two-word output and division of a two-word
- * numerator by a one-word denominator. The implementations of these operations are done with
- * inline assembly on x86 platforms with a Rust implementation as fallback.
- *
- * ## Integer representation
- *
- * Integers are passed around as pointers to a series of `Limb`s. The limbs are stored
- * least-significant first. If required, a size parameter is also provided, but otherwise is
- * omitted when it can be inferred from other sources of information. This is the case with the
- * output pointers used to store the result, they are assumed to have enough memory store the
- * result as the maximum output size is bounded by the size of the inputs.
- *
- * The integers are not required to be "normalized" in most cases. That is, they may have
- * zero-value limbs in the highest positions. Functions should aim to avoid requiring normalized
- * integers but otherwise explicitly document said requirement.
- *
- * ## Memory allocation
- *
- * No function will allocate memory for a return value. However, it is sometimes required to
- * allocate "scratch space" for storing intermediate values. This scratch space is always temporary
- * and freed before the function returns. Functions that need to make heavy use of scratch space
- * while also being recursive, are split so that scratch space can be re-used.
- *
- * ## Argument Conventions
- *
- * There are no hard-and-fast rules for the argument conventions in this module. There are however
- * some general conventions:
- *
- * * Output/Result pointer goes first (if applicable).
- * * Pointer and matching size are kept close together in the argument list.
- * * Sizes come after the matching pointers. For example, `add_n` takes two pointers and a length,
- *   the length applies to both pointers and so comes after both of them.
- */
+//! This module provides the low-level operations for working with arbitrary precision numbers.
+//!
+//! ## Overview
+//!
+//! This module forms the core of the library. As such, the functions are required to be highly
+//! performant, even small inefficiencies can cause a large impact given how frequently some of
+//! these functions are called. `addmul` for example is one of the most frequently called functions
+//! in the library, so an efficiencies there will be multiplied out to almost the entire library.
+//!
+//! There are no real restrictions on the functions that can implemented in here. Exposed functions
+//! should be generally useful to high-level code, but otherwise any operation that can be more
+//! efficiently implemented here and then exposed by a higher-level API is a candidate.
+//!
+//! The functions in this module assume that all inputs are valid, though some checking is performed
+//! in debug builds.
+//!
+//! ## Limbs
+//!
+//! A `Limb` is a single "digit" in an arbitrary-precision integer. To explain, consider the
+//! standard base we work in, base-10. Base-10 uses represents numbers as a sequence of the digits
+//! 0-9. The number 251 is 2 x 10^2 + 5 x 10^1 + 1 x 10^0. Similarly base-16 (hexadecimal) uses
+//! sixteen digits and a base of 16 to represent numbers.
+//!
+//! A `Limb` is one word, with N bits (32 on a 32-bit platform, 64 on a 64-bit platform), so it can
+//! represent 2^N unique values. It can therefore form the basis of a base-2^N number system. The
+//! word "Limb" is used by GMP to distinguish it from a regular numerical digit, and there is no
+//! obvious reason to use different terminology.
+//!
+//! `Limb` itself implements a number of useful methods. The basic mathematical operators are
+//! implemented to provide wrapping behaviour by default. The most basic operations are also
+//! implemented on `Limb`, notably multiplication with a two-word output and division of a two-word
+//! numerator by a one-word denominator. The implementations of these operations are done with
+//! inline assembly on x86 platforms with a Rust implementation as fallback.
+//!
+//! ## Integer representation
+//!
+//! Integers are passed around as pointers to a series of `Limb`s. The limbs are stored
+//! least-significant first. If required, a size parameter is also provided, but otherwise is
+//! omitted when it can be inferred from other sources of information. This is the case with the
+//! output pointers used to store the result, they are assumed to have enough memory store the
+//! result as the maximum output size is bounded by the size of the inputs.
+//!
+//! The integers are not required to be "normalized" in most cases. That is, they may have
+//! zero-value limbs in the highest positions. Functions should aim to avoid requiring normalized
+//! integers but otherwise explicitly document said requirement.
+//!
+//! ## Memory allocation
+//!
+//! No function will allocate memory for a return value. However, it is sometimes required to
+//! allocate "scratch space" for storing intermediate values. This scratch space is always temporary
+//! and freed before the function returns. Functions that need to make heavy use of scratch space
+//! while also being recursive, are split so that scratch space can be re-used.
+//!
+//! ## Argument Conventions
+//!
+//! There are no hard-and-fast rules for the argument conventions in this module. There are however
+//! some general conventions:
+//!
+//! * Output/Result pointer goes first (if applicable).
+//! * Pointer and matching size are kept close together in the argument list.
+//! * Sizes come after the matching pointers. For example, `add_n` takes two pointers and a length,
+//!   the length applies to both pointers and so comes after both of them.
 
 use std::intrinsics::abort;
 use std::cmp::Ordering;

--- a/src/rational.rs
+++ b/src/rational.rs
@@ -12,6 +12,8 @@
 //    See the License for the specific language governing permissions and
 //    limitations under the License.
 
+//! This module holds `Rational` and related types.
+
 #![allow(dead_code, unused_imports)]
 
 use std;
@@ -33,22 +35,19 @@ use int::{Int, ParseIntError};
 
 use ieee754::Ieee754;
 
-/**
- * An arbitrary-precision rational number.
- *
- * This type is used to represent numbers in the form `a / b` where `a` and `b`
- * are integers and `b` is non-zero.
- */
+/// An arbitrary-precision rational number.
+///
+/// This type is used to represent numbers in the form `a / b` where `a` and `b`
+/// are [`Int`]s and `b` is non-zero.
+///
+/// [`Int`]: ../int/struct.Int.html
 pub struct Rational {
     n: Int,
     d: Int
 }
 
 impl Rational {
-
-    /**
-     * Returns the absolute value of this Rational
-     */
+    /// Consumes this `Rational`, returning its absolute value.
     pub fn abs(mut self) -> Rational {
         if self.sign() == -1 {
             self.n *= -1;
@@ -56,6 +55,13 @@ impl Rational {
         self
     }
 
+    /// Creates a new `Rational` from a numerator `n` and denominator `d`.
+    ///
+    /// This method normalizes the `Rational`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `d` is zero.
     pub fn new(n: Int, d: Int) -> Rational {
         assert!(d != 0, "Denominator is zero");
 
@@ -76,25 +82,23 @@ impl Rational {
         rat
     }
 
-    /**
-     * Returns whether or not this rational is normalized or not
-     */
+    /// Returns whether or not this `Rational` is [normalized].
+    ///
+    /// [normalized]: #method.normalize
     pub fn normalized(&self) -> bool {
         let gcd = self.n.gcd(&self.d);
         gcd == 1
     }
 
-    /**
-     * Normalize this Rational.
-     *
-     * This method will cause the value to be represented in the
-     * form `a/b` where `a` and `b` are relatively prime. It also
-     * ensures that the denominator is positive.
-     *
-     * Normalizing rationals will result in faster calculations as
-     * it ensures that the numerator and denominator are as small as
-     * they can be.
-     */
+    /// Normalize this `Rational` in place.
+    ///
+    /// This method ensures that the `Rational` is represented in lowest forms, i.e. as `a/b` such
+    /// that `a` and `b` share no common factors. It also ensures that the denominator is positive.
+    ///
+    /// Normalizing rationals results in faster calculations, ensuring that the numerator and
+    /// denominator are as small as possible.
+    ///
+    /// Most of the time, this method is called automatically.
     pub fn normalize(&mut self) {
         let gcd = self.n.gcd(&self.d);
 
@@ -108,9 +112,7 @@ impl Rational {
         }
     }
 
-    /**
-     * Returns the reciprocal of this Rational
-     */
+    /// Consumes this `Rational`, returning its reciprocal.
     pub fn invert(self) -> Rational {
         if self.sign() == -1 {
             Rational {
@@ -125,9 +127,9 @@ impl Rational {
         }
     }
 
-    /**
-     * Returns this Rational to the nearest Int
-     */
+    /// Consumes this `Rational`, rounding it to the nearest `Int`.
+    ///
+    /// This method will round half values away from zero, similarly to `f64::round`.
     pub fn round(mut self) -> Int {
         let sign = self.sign();
         if sign == 0 {
@@ -142,10 +144,8 @@ impl Rational {
          }
     }
 
-    /**
-     * Returns the sign of the Int as either -1, 0 or 1 for self being negative, zero
-     * or positive, respectively.
-     */
+    /// Returns the sign of this `Rational` as either -1, 0 or 1 depending on whether it is
+    /// negative, zero, or positive, respectively.
     pub fn sign(&self) -> i32 {
         if self.n.sign() == 0 {
             0
@@ -156,9 +156,13 @@ impl Rational {
         }
     }
 
-    /**
-     * Converts this Rational to an `f64` value.
-     */
+    /// Converts this `Rational` into an `f64`.
+    ///
+    /// This is not an exact conversion, because this `Rational` may be more precise than an `f64`
+    /// can account for.
+    ///
+    /// Currently, this conversion is naïve, simply converting the numerator and denominator into
+    /// `f64`s and dividing them.
     pub fn to_f64(&self) -> f64 {
         let mut normalized = self.clone();
         normalized.normalize();
@@ -184,9 +188,7 @@ impl Clone for Rational {
 impl std::default::Default for Rational {
     #[inline]
     fn default() -> Rational {
-        Rational::new(
-            Int::zero(),
-            Int::one())
+        Rational::new(Int::zero(), Int::one())
     }
 }
 
@@ -884,6 +886,9 @@ macro_rules! impl_from_float {
 impl_from_float!(f32, 23);
 impl_from_float!(f64, 52);
 
+/// Error that arises when parsing a [`Rational`].
+///
+/// [`Rational`]: struct.Rational.html
 #[derive(Debug, Clone, PartialEq)]
 pub struct ParseRationalError(ParseIntError);
 

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -12,6 +12,9 @@
 //    See the License for the specific language governing permissions and
 //    limitations under the License.
 
+//! This module holds `Rational` and related types.
+
+/// A trait for types which can compute division and remainder in one step.
 pub trait DivRem<RHS = Self> {
     // Default to (Self, RHS) when associated type defaults are more stable.
     type Output;


### PR DESCRIPTION
The function Int::count_ones() returns the number of ones (population count, as rightly said in the docs). The docs however state number of "traliling" ones which is misleading. I would like to request we drop the term.

> Thanks for the PR! Would you mind rebasing it on the current `master`? It looks like most of these changes are wrt a 4 year old version of the repo.

I am very new to GitHub. I think I've added another PR to the main branch with the edit. I can't figure out how to delete this one. Kindly review the main PR and remove it if you can.
Thank you